### PR TITLE
fix: Use binary mode for output file

### DIFF
--- a/src/pooleditparser.cxx
+++ b/src/pooleditparser.cxx
@@ -207,7 +207,7 @@ int main(int argc, char *argv[])
         exit(-2);
     }
 
-    fileOut = fopen(argv[2], "w");
+    fileOut = fopen(argv[2], "wb");
     if (fileOut == NULL) {
         printf("Can't open file: %s\n", argv[2]);
         exit(-3);


### PR DESCRIPTION
Currently on Windows any `<LF>` characters are being prepended with `<CR>` as the file is open in text mode rather than binary. This change ensures that the binary files are correctly encoded.